### PR TITLE
Normalize public endpoints

### DIFF
--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -4,7 +4,7 @@ import { loadingSpinner } from './global/alerts.js';
 
 
 var element = '#calendar';
-var api = '../api.php';
+var api = '/api.php';
 
 $(function() {
     const calendarEl = document.getElementById('calendar');
@@ -56,7 +56,7 @@ $(function() {
         dateClick: async  function(info) {
             $("#addEventModalLabel").html('Agregar alumno para el '+info.dateStr+'');
             $("#addEventModal").modal('show');
-            $.post('../modals/addEvent.Modal.php', { date: info.dateStr }, function (data) {
+            $.post('/modals/addEvent.Modal.php', { date: info.dateStr }, function (data) {
                 $('#addEventModalBody').html(data);
             });
         },
@@ -67,7 +67,7 @@ $(function() {
             loadingSpinner(true, '#eventDetailsBody');
             $('#eventDetails').modal('show');
             $("#eventDetailsLabel").html(info.event.title);
-            await $.post('../modals/eventDetails.Modal.php', { eventId: info.event._def.publicId, eventData: info.event._def, dateTime : info.event._instance.range }, function (data) {                
+            await $.post('/modals/eventDetails.Modal.php', { eventId: info.event._def.publicId, eventData: info.event._def, dateTime : info.event._instance.range }, function (data) {
                 $('#eventDetailsBody').html(data);
             });
         },

--- a/public/js/careers.js
+++ b/public/js/careers.js
@@ -4,7 +4,7 @@
 $("#carreersTable").on("click", ".subjectsCarreer", function(){
     let careerId = $(this).data("id");
 
-    $.post('/public/modals/careersSubjects.Modal.php', { careerId: careerId }, function (data) {
+    $.post('/modals/careersSubjects.Modal.php', { careerId: careerId }, function (data) {
         $('#subjectsModalBody').html(data);
     });
 });

--- a/public/js/groupsDetails.js
+++ b/public/js/groupsDetails.js
@@ -2,7 +2,7 @@ import { initializeDataTable } from './global/dataTables.js';
 import { confirmAlert, successAlertAuto, errorAlert, loadingSpinner } from './global/alerts.js';
 import { sendFetch } from './global/fetchCall.js';
 
-const callback = '/public/api.php';
+const callback = '/api.php';
 
 $(function() {
     getStudentsList($('#studentIdGroup'));

--- a/public/js/groupsSchedules.js
+++ b/public/js/groupsSchedules.js
@@ -2,7 +2,7 @@ import { initializeDataTable } from './global/dataTables.js';
 import { confirmAlert, successAlertAuto, errorAlert, loadingAlert } from './global/alerts.js';
 import { sendFetch } from './global/fetchCall.js';
 
-const callback = '/public/api.php';
+const callback = '/api.php';
 
 $(function () {
     var groupId = $('#groupId').val();

--- a/public/js/hoursHistorial.js
+++ b/public/js/hoursHistorial.js
@@ -2,7 +2,7 @@ import { initializeDataTable } from './global/dataTables.js';
 import { confirmAlert, successAlertAuto, errorAlert, loadingSpinner } from './global/alerts.js';
 import { sendFetch } from './global/fetchCall.js';
 
-const callback = '../api.php';
+const callback = '/api.php';
 
 $(function() {
     
@@ -32,13 +32,13 @@ $(function() {
 
 const modalTotal = async (id, total) => {
     loadingSpinner('#seeTotalModalBody');
-    await $.post('../modals/seeTotal.Modal.php', { id: id, total: total}, function (data) {
+    await $.post('/modals/seeTotal.Modal.php', { id: id, total: total}, function (data) {
         $('#seeTotalModalBody').html(data);
     });
 }
 
 const addHours = async (id) => {
-    await $.post('../modals/addHours.Modal.php', { id: id }, function (data) {
+    await $.post('/modals/addHours.Modal.php', { id: id }, function (data) {
         $('#addHoursModalBody').html(data);
     });
 }

--- a/public/js/notes.js
+++ b/public/js/notes.js
@@ -5,7 +5,7 @@ import { sendFetch } from './global/fetchCall.js';
 let urlParams = new URLSearchParams(window.location.search);
 let studentIdGroup = urlParams.get('student'); 
 
-let api = '/public/api.php';
+let api = '/api.php';
 
 let studentName;
 
@@ -48,7 +48,7 @@ $("#studentGradesTable").on('click', '.studentGrade', function () {
         'Recursamiento para ' + studentName + ' - ' + subjectName + '  ' + (subjectChildName ? subjectChildName : '')
       );
     $("#makeOverExamModal").modal('show');
-    $.post('/public/modals/makeOverExam.Modal.php', { studentId: studentIdGroup, subjectId: subjectId, subjectName : subjectName, subjectChildName: subjectChildName, subjectChildId: subjectChildId, gradeId: gradeId }, function (data) {
+    $.post('/modals/makeOverExam.Modal.php', { studentId: studentIdGroup, subjectId: subjectId, subjectName : subjectName, subjectChildName: subjectChildName, subjectChildId: subjectChildId, gradeId: gradeId }, function (data) {
         $('#makeOverExamModalBody').html(data);
     });
 });
@@ -66,7 +66,7 @@ $("#studentGradesTable").on('click', '.mekeOver', function () {
         'calificacion de Recursamiento para ' + studentName
       );
     $("#makeOverViewModal").modal('show');
-    $.post('/public/modals/viewMakeOver.Modal.php', { studentId: studentIdGroup, makeOverId: makeOverId }, function (data) {
+    $.post('/modals/viewMakeOver.Modal.php', { studentId: studentIdGroup, makeOverId: makeOverId }, function (data) {
         $('#makeOverViewModalBody').html(data);
     });
 });
@@ -84,7 +84,7 @@ $("#studentGradesTable").on('click', '.makeOverChild', function () {
         'calificacion de Recursamiento para ' + studentName
       );
     $("#makeOverViewModal").modal('show');
-    $.post('/public/modals/viewMakeOver.Modal.php', { studentId: studentIdGroup, makeOverChildId: makeOverChildId }, function (data) {
+    $.post('/modals/viewMakeOver.Modal.php', { studentId: studentIdGroup, makeOverChildId: makeOverChildId }, function (data) {
         $('#makeOverViewModalBody').html(data);
     });
 });

--- a/public/js/students.js
+++ b/public/js/students.js
@@ -2,7 +2,7 @@ import { initializeDataTable } from './global/dataTables.js';
 import { confirmAlert, successAlertAuto, errorAlert, loadingSpinner } from './global/alerts.js';
 import { sendFetch } from './global/fetchCall.js';
 
-const callback = '../api.php';
+const callback = '/api.php';
 
 $(function() {
     

--- a/public/js/students/index.js
+++ b/public/js/students/index.js
@@ -61,7 +61,7 @@ $('#studentTable').on('click', '.badge', async function() {
     let studentName = $(this).data('name');
     let studentStatus = $(this).data('status');
 
-    await $.post('/public/modals/studentStatus.modal.php', { studentId: studentId,studentName: studentName, studentStatus: studentStatus }, function (data) {
+    await $.post('/modals/studentStatus.modal.php', { studentId: studentId,studentName: studentName, studentStatus: studentStatus }, function (data) {
         $("#statusModal").modal('show');
         $('#statusModalBody').html(data);
     });

--- a/public/modals/studentStatus.modal.php
+++ b/public/modals/studentStatus.modal.php
@@ -61,7 +61,7 @@ $studentStatus = $_POST['studentStatus'] ?? NULL;
     import { errorAlert, successAlert, infoAlert, loadingSpinner, loadingAlert } from '<?php echo $_ENV['BASE_URL']; ?>/js/utils/alerts.js';
     import { sendFetch } from '<?php echo $_ENV['BASE_URL']; ?>/js/global/fetchCall.js';
 
-    let api = '/public/api.php';
+    let api = '<?php echo $_ENV['BASE_URL']; ?>/api.php';
 
     $('#addEvent').submit(function(e) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- Align public JavaScript files with current project structure by pointing API calls to `/api.php`
- Correct modal references to use root-level `/modals` path
- Use environment-based base URL in `studentStatus` modal

## Testing
- `for f in public/js/notes.js public/js/students/index.js public/js/careers.js public/js/calendar.js public/js/hoursHistorial.js public/js/students.js public/js/groupsDetails.js public/js/groupsSchedules.js; do echo Checking $f; node --check $f; done`
- `php -l public/modals/studentStatus.modal.php`


------
https://chatgpt.com/codex/tasks/task_e_68c07cc04a88832b90be4fc0f345b5ba