### PR TITLE
feat: agregar helper de verificación de sesión

### DIFF
--- a/backend/src/auth.php
+++ b/backend/src/auth.php
@@ -44,4 +44,21 @@ class auth {
         }
     }
 
+    public static function check(){
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        $jwt = $_COOKIE['auth'] ?? NULL;
+
+        $result = self::verify($jwt);
+
+        if(!$result['success']){
+            setcookie('auth', '', time() - 3600, '/');
+            session_unset();
+        }
+
+        return $result;
+    }
+
 }

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -5,12 +5,8 @@ use Vendor\Schoolarsystem\auth;
 use Vendor\Schoolarsystem\DBConnection;
 use Vendor\Schoolarsystem\userData;
 use Vendor\Schoolarsystem\MicrosoftActions;
-use Vendor\Schoolarsystem\loadEnv;
 
-session_start();
-
-loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/index.php
+++ b/public/index.php
@@ -3,9 +3,7 @@ require_once(__DIR__.'/../backend/vendor/autoload.php');
 
 use Vendor\Schoolarsystem\auth;
 
-session_start();
-
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $userId = $VerifySession['userId'] ?? NULL;
 


### PR DESCRIPTION
## Summary
- Añade `auth::check` para validar sesión y limpiar estado inválido
- Adapta index y dashboard para usar la nueva función

## Testing
- `php -l backend/src/auth.php`
- `php -l public/index.php`
- `php -l public/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68c08604891c832bb270c9c28744af08