### PR TITLE
feat: add consolidated session check

### DIFF
--- a/backend/carreers/index.php
+++ b/backend/carreers/index.php
@@ -14,7 +14,7 @@ class CareersControl{
     }
 
     public function getCareers(){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
        if(!$VerifySession['success']){
            return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -46,7 +46,7 @@ class CareersControl{
     }
 
     public function getCareer($idCarreer){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
        if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -77,7 +77,7 @@ class CareersControl{
     }
 
     public function addCarreer($carreerData){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
        if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -99,7 +99,7 @@ class CareersControl{
     }
 
     public function updateCarreer($carreerDataEditArray){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
        if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -121,7 +121,7 @@ class CareersControl{
     }
 
     public function deleteCarreer($idCarreer){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
        if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -143,7 +143,7 @@ class CareersControl{
     }
 
     public function getSubjects($carreerId){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -175,7 +175,7 @@ class CareersControl{
     }
 
     public function getChildSubjects($subjectID){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -207,7 +207,7 @@ class CareersControl{
     }
 
     public function addSubjectsCarreer($subjectsCarreerArray){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{

--- a/backend/groups/index.php
+++ b/backend/groups/index.php
@@ -15,7 +15,7 @@ class GroupsControl{
     }
     
         public function GetGroups(){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -48,7 +48,7 @@ class GroupsControl{
         }
 
         public function GetGroupsStudents($groupId){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -79,7 +79,7 @@ class GroupsControl{
         }
 
         public function GetStudentsNames(){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -108,7 +108,7 @@ class GroupsControl{
         }
 
         public function GetGroupData($groupId){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -143,7 +143,7 @@ class GroupsControl{
         }
 
         public function GetGroupsJson(){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -182,7 +182,7 @@ class GroupsControl{
         }
     
         public function AddGroup($groupDataArray){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -204,7 +204,7 @@ class GroupsControl{
         }
     
         public function UpdateGroup($groupDataEditArray){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -226,7 +226,7 @@ class GroupsControl{
         }
     
         public function DeleteGroup($groupId){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -247,7 +247,7 @@ class GroupsControl{
         }
 
         public function AddStudentGroup($groupId, $studentId){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -278,7 +278,7 @@ class GroupsControl{
         }
 
         public function DeleteStudentGroup($studentId){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{

--- a/backend/payments/index.php
+++ b/backend/payments/index.php
@@ -21,7 +21,7 @@ class PaymentsControl{
     }
 
     public function VerifyTaxData($studentId){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -49,7 +49,7 @@ class PaymentsControl{
     }
 
     public function GetFacturApiData($clientId){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -114,7 +114,7 @@ class PaymentsControl{
     }
 
     public function AddPayment($paymentDataArray){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
         return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -244,7 +244,7 @@ class PaymentsControl{
     }
 
     public function GetStudentsPayMount(){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -287,7 +287,7 @@ class PaymentsControl{
     }
 
     public function SetStudentPayMount($studentId, $amount){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -314,7 +314,7 @@ class PaymentsControl{
     }
 
     public function VerifyMonthlyPayment($studentId){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{

--- a/backend/src/auth.php
+++ b/backend/src/auth.php
@@ -44,4 +44,17 @@ class auth {
         }
     }
 
+    public static function check(){
+        $jwt = $_COOKIE['auth'] ?? NULL;
+        $verification = self::verify($jwt);
+        if(!$verification['success']){
+            if(isset($_COOKIE['auth'])){
+                setcookie('auth', '', time() - 3600, '/');
+            }
+            session_unset();
+            session_destroy();
+        }
+        return $verification;
+    }
+
 }

--- a/backend/students/index.php
+++ b/backend/students/index.php
@@ -20,7 +20,7 @@ class StudentsControl {
     }
     public function GetStudents(){
 
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -66,7 +66,7 @@ class StudentsControl {
 
     function GetStudent($studentId){
 
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -106,7 +106,7 @@ class StudentsControl {
 
     function AddStudent($studentDataArray){
             
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -152,7 +152,7 @@ class StudentsControl {
 
     function UpdateStudent($studentDataArray){
 
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -180,7 +180,7 @@ class StudentsControl {
 
     function UpdateStatus($statusDataArray){
             
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -204,7 +204,7 @@ class StudentsControl {
 
     function DeleteStudent($studentId){
 
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -227,7 +227,7 @@ class StudentsControl {
     }
 
     public function GetStudentsNames(){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -258,7 +258,7 @@ class StudentsControl {
 
     function GetStudentsUsers(){
 
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -293,7 +293,7 @@ class StudentsControl {
 
     function GetMicrosoftStudentsUsers(){
 
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -327,7 +327,7 @@ class StudentsControl {
 
     function VerifyStudentUser($studentUser){
             
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -347,7 +347,7 @@ class StudentsControl {
 
     function AddStudentUser($studentDataArray){
                 
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -371,7 +371,7 @@ class StudentsControl {
 
     function UpdateStudentUser($studentEditDataArray){
             
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -394,7 +394,7 @@ class StudentsControl {
 
     function DesactivateStudentUser($studentId){
             
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -418,7 +418,7 @@ class StudentsControl {
 
     function ReactivateStudentUser($studentId){
             
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -442,7 +442,7 @@ class StudentsControl {
 
     public function GetSubjectsNames($carrerId){
             
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -479,7 +479,7 @@ class StudentsControl {
 
     public function GetChildSubjectsNames($idSubject){
             
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -515,7 +515,7 @@ class StudentsControl {
 
     public function VerifyGroupStudent($studentIdGroup){
             
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -534,7 +534,7 @@ class StudentsControl {
     }
 
     public function GetStudentGrades($studentId){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if (!$VerifySession['success']) :
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         endif;
@@ -626,7 +626,7 @@ class StudentsControl {
     }
 
     public function AddGradeStudent($gradeDataArray) {
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if (!$VerifySession['success']) :
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         endif;
@@ -722,7 +722,7 @@ class StudentsControl {
 
     public function GetGroupsNames(){
 
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -755,7 +755,7 @@ class StudentsControl {
 
     public function addStudentGroup($studentGroupDataArray){
             
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -777,7 +777,7 @@ class StudentsControl {
     }
     
     public function SearchMicrosoftUser($displayName){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
             if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{

--- a/backend/subjects/index.php
+++ b/backend/subjects/index.php
@@ -16,7 +16,7 @@ class SubjectsControl{
     }
     
     public function GetSubjects(){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -61,7 +61,7 @@ LEFT JOIN subject_child ON subjects.id = subject_child.id_subject;";
     }
 
     public function GetSubjectData($subjectId){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -90,7 +90,7 @@ LEFT JOIN subject_child ON subjects.id = subject_child.id_subject;";
     }
 
     public function AddSubject($subjectDataArray){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -109,7 +109,7 @@ LEFT JOIN subject_child ON subjects.id = subject_child.id_subject;";
     }
 
     public function UpdateSubjectData($subjectDataEditArray){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -128,7 +128,7 @@ LEFT JOIN subject_child ON subjects.id = subject_child.id_subject;";
     }
 
     public function DeleteSubject($subjectId){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -158,7 +158,7 @@ class SubjectsControlChild extends SubjectsControl{
 
     public function AddSubjectChild($subjectChildDataArray){
         
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -189,7 +189,7 @@ class SubjectsControlChild extends SubjectsControl{
     }
 
     public function GetSubjectChildData($subjectFatherId, $subjectChildId){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{
@@ -218,7 +218,7 @@ class SubjectsControlChild extends SubjectsControl{
     }
 
     public function UpdateSubjectChild ($subjectChildDataEditArray){
-        $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+        $VerifySession = auth::check();
         if(!$VerifySession['success']){
             return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
         }else{

--- a/backend/teachers/index.php
+++ b/backend/teachers/index.php
@@ -16,7 +16,7 @@ class TeachersControl{
     }
     
         public function GetTeachers(){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -47,7 +47,7 @@ class TeachersControl{
         }
 
         public function GetTeacher($idTeacher){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -80,7 +80,7 @@ class TeachersControl{
         }
 
         public function AddTeacher($teacherData){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -102,7 +102,7 @@ class TeachersControl{
         }
 
         public function UpdateTeacherData($teacherData){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -125,7 +125,7 @@ class TeachersControl{
         }
 
         public function DeleteTeacher($teacherId){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -147,7 +147,7 @@ class TeachersControl{
         }
 
         function GetTeachersUsers(){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -181,7 +181,7 @@ class TeachersControl{
         }
 
         function VerifyTeacherUser($teacherUserAdd){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -199,7 +199,7 @@ class TeachersControl{
         }
 
         function AddTeacherUser($teacherUserAddArray){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -222,7 +222,7 @@ class TeachersControl{
         }
 
         function DesactivateTeacherUser($teacherUserId){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -245,7 +245,7 @@ class TeachersControl{
         }
 
         function ReactivateTeacherUser($teacherUserId){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{
@@ -268,7 +268,7 @@ class TeachersControl{
         }
 
         function UpdateTeacherUserData($teacherUserDataArray){
-            $VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+            $VerifySession = auth::check();
             if(!$VerifySession['success']){
                 return array("success" => false, "message" => "No se ha iniciado sesión o la sesión ha expirado");
             }else{

--- a/backend/views/mainMenu.php
+++ b/backend/views/mainMenu.php
@@ -8,7 +8,7 @@ use Vendor\Schoolarsystem\MicrosoftActions;
 use Vendor\Schoolarsystem\loadEnv;
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/alumnos.php
+++ b/public/alumnos.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/alumnos/altas.php
+++ b/public/alumnos/altas.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/alumnos/calificaciones.php
+++ b/public/alumnos/calificaciones.php
@@ -9,7 +9,7 @@ use Vendor\Schoolarsystem\MicrosoftActions;
 
 session_start();
 
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/alumnos/usuarios.php
+++ b/public/alumnos/usuarios.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/carreras.php
+++ b/public/carreras.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/carreras/altas.php
+++ b/public/carreras/altas.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/grupos.php
+++ b/public/grupos.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/grupos/altas.php
+++ b/public/grupos/altas.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/grupos/detalles.php
+++ b/public/grupos/detalles.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/grupos/horarios.php
+++ b/public/grupos/horarios.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/index.php
+++ b/public/index.php
@@ -5,7 +5,7 @@ use Vendor\Schoolarsystem\auth;
 
 session_start();
 
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $userId = $VerifySession['userId'] ?? NULL;
 

--- a/public/materias.php
+++ b/public/materias.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/materias/altas.php
+++ b/public/materias/altas.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/modals/addEvent.Modal.php
+++ b/public/modals/addEvent.Modal.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/modals/addHours.Modal.php
+++ b/public/modals/addHours.Modal.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/modals/careersSubjects.Modal.php
+++ b/public/modals/careersSubjects.Modal.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/modals/eventDetails.Modal.php
+++ b/public/modals/eventDetails.Modal.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/modals/makeOverExam.Modal.php
+++ b/public/modals/makeOverExam.Modal.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/modals/seeTotal.Modal.php
+++ b/public/modals/seeTotal.Modal.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/modals/studentStatus.modal.php
+++ b/public/modals/studentStatus.modal.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/modals/viewMakeOver.Modal.php
+++ b/public/modals/viewMakeOver.Modal.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/pagos/fechas-pago.php
+++ b/public/pagos/fechas-pago.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/pagos/nuevo-pago.php
+++ b/public/pagos/nuevo-pago.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/practicas/calendario.php
+++ b/public/practicas/calendario.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/practicas/historial.php
+++ b/public/practicas/historial.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/profesores.php
+++ b/public/profesores.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/profesores/altas.php
+++ b/public/profesores/altas.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();

--- a/public/profesores/usuarios.php
+++ b/public/profesores/usuarios.php
@@ -10,7 +10,7 @@ use Vendor\Schoolarsystem\loadEnv;
 session_start();
 
 loadEnv::cargar();
-$VerifySession = auth::verify($_COOKIE['auth'] ?? NULL);
+$VerifySession = auth::check();
 
 $dbConnection = new DBConnection();
 $connection = $dbConnection->getConnection();


### PR DESCRIPTION
## Summary
- add new `auth::check` helper to validate JWT cookie and clean stale sessions
- replace scattered `auth::verify` calls with `auth::check` for simpler usage

## Testing
- `git diff --name-only | xargs -n 1 php -l`
- `composer dump-autoload`

------
https://chatgpt.com/codex/tasks/task_e_68c08604891c832bb270c9c28744af08