### PR TITLE
Fix teacher session check

### DIFF
--- a/backend/src/auth.php
+++ b/backend/src/auth.php
@@ -45,14 +45,21 @@ class auth {
     }
 
    public static function check(){
+        if(session_status() === PHP_SESSION_NONE){
+            session_start();
+        }
+
         $jwt = $_COOKIE['auth'] ?? NULL;
         $verification = self::verify($jwt);
+
         if(!$verification['success']){
             if(isset($_COOKIE['auth'])){
                 setcookie('auth', '', time() - 3600, '/');
             }
-            session_unset();
-            session_destroy();
+            if(session_status() === PHP_SESSION_ACTIVE){
+                session_unset();
+                session_destroy();
+            }
         }
         return $verification;
     }

--- a/backend/teachers/routes.php
+++ b/backend/teachers/routes.php
@@ -1,5 +1,6 @@
 <?php
 require_once(__DIR__.'/../vendor/autoload.php');
+session_start();
 
 use Vendor\Schoolarsystem\DBConnection;
 use Vendor\Schoolarsystem\Controllers\TeachersController;


### PR DESCRIPTION
## Summary
- Ensure authentication helper initializes/destroys sessions safely
- Start PHP session in teacher routes before handling requests

## Testing
- `php -l backend/src/auth.php`
- `php -l backend/teachers/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa0496b4832bbd33d80552f24df9