### PR TITLE
Fix Google Calendar client class usage

### DIFF
--- a/backend/src/Models/GoogleCalendarModel.php
+++ b/backend/src/Models/GoogleCalendarModel.php
@@ -5,6 +5,7 @@ namespace Vendor\Schoolarsystem\Models;
 use Google\Client;
 use Google\Service\Calendar;
 use Google\Service\Calendar\Event;
+use Google\Service\Calendar\EventDateTime;
 use Vendor\Schoolarsystem\loadEnv;
 
 date_default_timezone_set('America/Monterrey');
@@ -18,10 +19,10 @@ class GoogleCalendarModel{
     public function addEventCalendar($tittle, $date, $startEvent, $endEvent){
         putenv('GOOGLE_APPLICATION_CREDENTIALS=' . __DIR__ . '/calendario-alumnos.json');
 
-        $client = new Google_Client();
+        $client = new Client();
         $client->useApplicationDefaultCredentials();
-        $client->setScopes(['https://www.googleapis.com/auth/calendar']);  
-        $calendarService = new Google_Service_Calendar($client);  
+        $client->setScopes(['https://www.googleapis.com/auth/calendar']);
+        $calendarService = new Calendar($client);
 
         $datetimeStart = new DateTime($date . ' ' . $startEvent);
         $datetimeEnd = new DateTime($date . ' ' . $endEvent);
@@ -29,16 +30,16 @@ class GoogleCalendarModel{
         $timeStartFormat =$datetimeStart->format(\DateTime::RFC3339);
         $timeEndFormat = $datetimeEnd->format(\DateTime::RFC3339);
 
-        $event = new Google_Service_Calendar_Event();
+        $event = new Event();
         $event->setSummary($tittle);
         $event->setDescription('Alumno '.$tittle. ' se registra para practicas clinicas');
 
-        $start = new Google_Service_Calendar_EventDateTime();
+        $start = new EventDateTime();
         $start->setDateTime($timeStartFormat);
 
         $event->setStart($start);
 
-        $end = new Google_Service_Calendar_EventDateTime();
+        $end = new EventDateTime();
         $end->setDateTime($timeEndFormat);
 
         $event->setEnd($end);


### PR DESCRIPTION
## Summary
- use the namespaced Google API client and calendar classes that are already imported via Composer
- instantiate EventDateTime via its namespaced class to avoid PHP looking for classes within the project namespace

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68cd9d9d7d4c832bb5bed73a73ffa180